### PR TITLE
Update libtiff with new CMake changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 
-project(vc-deps VERSION 1.8.1)
+project(vc-deps VERSION 1.8.2)
 
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/)
 

--- a/cmake/BuildTIFF.cmake
+++ b/cmake/BuildTIFF.cmake
@@ -3,8 +3,8 @@ if(VCDEPS_BUILD_TIFF)
 externalproject_add(
     libtiff
     DEPENDS zlib ${GLOBAL_DEPENDS}
-    URL https://gitlab.com/libtiff/libtiff/-/archive/5e18004500cda10d9074bdb6166b054e95b659ed/libtiff-5e18004500cda10d9074bdb6166b054e95b659ed.tar.gz
-    URL_HASH SHA512=cf19fbfcc278fe9d113035db0aa4df56f461ba311394c40d43dd5da9f9a3e4a399acf885c57c3511e16cc396a90db0965e99440cebc40f45ac1e404e59196d08
+    GIT_REPOSITORY https://gitlab.com/libtiff/libtiff.git
+    GIT_TAG origin/cmake-cmath-avoid-imported-target
     DOWNLOAD_NO_PROGRESS true
     DOWNLOAD_EXTRACT_TIMESTAMP ON
     CMAKE_CACHE_ARGS

--- a/cmake/BuildTIFF.cmake
+++ b/cmake/BuildTIFF.cmake
@@ -4,7 +4,7 @@ externalproject_add(
     libtiff
     DEPENDS zlib ${GLOBAL_DEPENDS}
     GIT_REPOSITORY https://gitlab.com/libtiff/libtiff.git
-    GIT_TAG origin/cmake-cmath-avoid-imported-target
+    GIT_TAG 2653d1f8
     DOWNLOAD_NO_PROGRESS true
     DOWNLOAD_EXTRACT_TIMESTAMP ON
     CMAKE_CACHE_ARGS


### PR DESCRIPTION
Install with the latest version of libtiff once the [CMake issues are fixed](https://gitlab.com/libtiff/libtiff/-/issues/625).